### PR TITLE
Drop kodi-repository-kodi, it isn't needed (and comes from the Ubuntu archive)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,7 +75,6 @@ parts:
       snapcraftctl stage
     stage-packages:
       - kodi-wayland
-      - kodi-repository-kodi
       - kodi-visualization-spectrum
       - samba-libs
       - libfstrcmp0


### PR DESCRIPTION
Drop kodi-repository-kodi, it isn't needed (and comes from the Ubuntu archive).