### PR TITLE
Add i965-va-driver for video decoding

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,9 +82,11 @@ parts:
       - libpulse0
 
   mesa:
-    plugin: nil
+    plugin: ppa
+    ppa: wsnipex/vaapi
     stage-packages:
       - libgl1-mesa-dri
+      - i965-va-driver
 
   mir-kiosk-snap-launch:
     plugin: dump


### PR DESCRIPTION
Add i965-va-driver for video decoding.

This (experimentally) uses ppa:wsnipex/vaapi for i965-va-driver 2.3.0