### PR TITLE
[snap] use `on:` for the inputstream

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,7 +100,7 @@ parts:
       - kodi-wayland
       - kodi-visualization-spectrum
       - kodi-repository-kodi
-      - to amd64,i386: [kodi-inputstream-adaptive] # only available for x86
+      - on amd64,i386: [kodi-inputstream-adaptive] # only available for x86
       - python
       - samba-libs
       - samba-common-bin


### PR DESCRIPTION
`to:` doesn't work unless it's cross-building.