### PR TITLE
Fix packaging from ppa:team-xbmc

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,19 +96,17 @@ parts:
       snapcraftctl set-version $kodi_version
     stage-packages:
       - kodi
-      - on amd64: [python3]
-      - else: [kodi-wayland, python]
-      - on amd64,i386: [kodi-inputstream-adaptive]
+      - to amd64: [kodi-inputstream-adaptive, python3, libsndio7.0]
+      - to i386:  [kodi-inputstream-adaptive, python3, libsndio6.1]
+      - to armhf: [kodi-wayland, kodi-repository-kodi, python, libsndio7.0]
+      - to arm64: [kodi-wayland, kodi-repository-kodi, python, libsndio7.0]
       - kodi-visualization-spectrum
-      - kodi-repository-kodi
       - samba-libs
       - samba-common-bin
       - samba-common
       - libfstrcmp0
       - libpulse0
       - libaudio2
-      - try: [libsndio7.0]  # core20
-      - else: [libsndio6.1] # core18
   mesa:
     plugin: nil
     stage-packages:


### PR DESCRIPTION
This was missing inputstream.adaptive which affected a number of plugins. (I noticed it with iPlayer WWW)