### PR TITLE
Add $SNAP/graphics/libdrm to layout

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,8 @@ layout:
     bind: $SNAP/usr/share/samba
   /usr/share/X11/xkb:
     bind: $SNAP/usr/share/X11/xkb
+  /usr/share/libdrm:
+    bind: $SNAP/graphics/libdrm
 
 plugs:
   wayland:


### PR DESCRIPTION
Add $SNAP/graphics/libdrm to layout (per https://github.com/MirServer/mesa-core20/pull/11)

As described in:

https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000/3