### PR TITLE
snap: refresh to core22

### DIFF
--- a/glue/bin/run-kodi
+++ b/glue/bin/run-kodi
@@ -2,6 +2,6 @@
 
 # avoid unavailable python bits
 
-unset PYTHONPATH PYTHONHOME
+unset PYTHONPATH PYTHONHOME GCONV_PATH
 
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,10 @@
 name: mir-kiosk-kodi
 adopt-info: kodi
-summary: Kodi packaged as a mir-kiosk snap
-description: Kodi packaged as a mir-kiosk snap
+summary: Kodi packaged as a Frame snap
+description: Kodi packaged as a Frame snap
 confinement: strict
 grade: stable
-base: core20
+base: core22
 license: GPL-2.0
 
 architectures:
@@ -16,56 +16,39 @@ architectures:
 environment:
   SHELL: bash
   LC_ALL: C.UTF-8
-  LD_LIBRARY_PATH:    $SNAP/graphics/lib
-  LIBGL_DRIVERS_PATH: $SNAP/graphics/dri
-  LIBVA_DRIVERS_PATH: $SNAP/graphics/dri
-  __EGL_VENDOR_LIBRARY_DIRS: $SNAP/graphics/glvnd/egl_vendor.d
   # XDG config
   XDG_CACHE_HOME:  $SNAP_USER_COMMON/.cache
   XDG_CONFIG_HOME: $SNAP_USER_DATA/.config
   WINDOWING: wayland
 
 layout:
-  /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/kodi:
-    bind: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/kodi
-  /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio:
-    bind: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio
-  /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/samba:
-    bind: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/samba
+  /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/kodi:
+    bind: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/kodi
+  /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/pulseaudio:
+    bind: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/pulseaudio
+  /usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/samba:
+    bind: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/samba
   /usr/share/kodi:
     bind: $SNAP/usr/share/kodi
   /usr/share/samba:
     bind: $SNAP/usr/share/samba
   /usr/share/X11/xkb:
     bind: $SNAP/usr/share/X11/xkb
-  /usr/share/libdrm:  # Needed by mesa-core20 on AMD GPUs
+  /usr/share/libdrm:
     bind: $SNAP/graphics/libdrm
-  /usr/share/drirc.d:  # Used by mesa-core20 for app specific workarounds
-    bind: $SNAP/graphics/drirc.d
+  /usr/share/drirc.d:
+    symlink: $SNAP/graphics/drirc.d
 
 plugs:
-  wayland:
-  opengl:
-  audio-playback:
-  pulseaudio:
-  alsa:
-  avahi-observe:
-  hardware-observe:
-  locale-control:
-  mount-observe:
-  network-bind:
-  network-observe:
-  removable-media:
-  shutdown:
-  system-observe:
-  graphics-core20:
+  graphics-core22:
     interface: content
     target: $SNAP/graphics
-    default-provider: mesa-core20
+    default-provider: mesa-core22
 
 apps:
   daemon:
     command-chain:
+    - bin/graphics-core22-wrapper
     - bin/run-daemon
     - bin/wayland-launch
     - bin/run-kodi
@@ -76,9 +59,26 @@ apps:
       # Prep PulseAudio
       PULSE_SYSTEM: 1
       PULSE_RUNTIME_PATH: /var/run/pulse
+    plugs: &plugs
+    - alsa
+    - audio-playback
+    - avahi-observe
+    - graphics-core22
+    - hardware-observe
+    - locale-control
+    - mount-observe
+    - network-bind
+    - network-observe
+    - opengl
+    - pulseaudio
+    - removable-media
+    - shutdown
+    - system-observe
+    - wayland
 
   mir-kiosk-kodi:
     command-chain:
+    - bin/graphics-core22-wrapper
     - bin/wayland-launch
     - bin/run-kodi
     command: usr/bin/kodi
@@ -86,65 +86,55 @@ apps:
     environment:
       # Prep PulseAudio
       PULSE_SERVER: unix:$XDG_RUNTIME_DIR/../pulse/native
-
-package-repositories:
-  - type: apt
-    ppa: wsnipex/vaapi
+    plugs: *plugs
 
 parts:
-  ppa-setup:
-    plugin: nil
-    # Use the upstream PPA where possible
-    override-pull: |
-      if [ "$SNAP_ARCH" = "amd64" ] || [ "$SNAP_ARCH" = "i386" ]; then
-        sudo apt --assume-yes install software-properties-common
-        sudo add-apt-repository -yu ppa:team-xbmc/ppa
-        snapcraftctl pull
-      fi
-
   glue:
     plugin: dump
     source: glue
 
   kodi:
-    after: [ ppa-setup ]
     plugin: nil
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       kodi_version=`LANG=C apt-cache policy kodi | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
-      snapcraftctl set-version $kodi_version
+      craftctl set version=$kodi_version
     stage-packages:
       - kodi
-      - to amd64: [kodi-inputstream-adaptive, python3, libsndio7.0]
-      - to i386:  [kodi-inputstream-adaptive, python3, libsndio6.1]
-      - to armhf: [kodi-wayland, kodi-repository-kodi, python, libsndio7.0]
-      - to arm64: [kodi-wayland, kodi-repository-kodi, python, libsndio7.0]
+      - kodi-data
+      - kodi-inputstream-adaptive
+      - kodi-inputstream-ffmpegdirect
+      - kodi-repository-kodi
       - kodi-visualization-spectrum
+      - python3
       - samba-libs
       - samba-common-bin
       - samba-common
+      - libblas3
+      - liblapack3
       - libfstrcmp0
       - libpulse0
-      - libaudio2
+    organize:
+      usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/blas/*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
+      usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/lapack/*: usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/
 
-  mir-kiosk-snap-launch:
+  setup:
     plugin: dump
-    source: https://github.com/MirServer/mir-kiosk-snap-launch.git
+    source: wayland-launch
     override-build: |
-      sed "s/^exec /WAYLAND_DISPLAY=\${WAYLAND_DISPLAY:-wayland-0} exec /" -i $SNAPCRAFT_PART_BUILD/bin/wayland-launch
-      $SNAPCRAFT_PART_BUILD/build-with-plugs.sh opengl wayland graphics-core20 network-observe network-bind audio-playback
+      PLUGS="opengl wayland graphics-core22 network-observe network-bind audio-playback"
+      sed --in-place "s/%PLUGS%/$PLUGS/g" $CRAFT_PART_BUILD/bin/wayland-launch
+      sed --in-place "s/%PLUGS%/$PLUGS/g" $CRAFT_PART_BUILD/bin/setup.sh
+      craftctl default
     stage-packages:
       - inotify-tools
 
-  cleanup:
-    after: [kodi, mir-kiosk-snap-launch]
-    plugin: nil
-    build-snaps: [ mesa-core20 ]
+  graphics-core22:
+    after: [kodi, setup]
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
     override-prime: |
-      set -eux
-      cd /snap/mesa-core20/current/egl/lib
-      find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/{} \;
-      rm -fr "$SNAPCRAFT_PRIME/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri"
-      for CRUFT in bug drirc.d glvnd libdrm lintian man; do
-        rm -rf "$SNAPCRAFT_PRIME/usr/share/$CRUFT"
-      done
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
+    prime:
+    - bin/graphics-core22-wrapper

--- a/wayland-launch/bin/run-daemon
+++ b/wayland-launch/bin/run-daemon
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -x
+
+if [ "$(snapctl get daemon)" = "true" ]
+then exec "$@"
+else
+  # It is unlikely, but possible for "snapctl stop ..." to fail
+  # temporarily (e.g. during install/refresh).
+  # Handle failure by ignoring it: it will work next retry.
+  snapctl stop $SNAP_INSTANCE_NAME.daemon || true
+fi

--- a/wayland-launch/bin/setup.sh
+++ b/wayland-launch/bin/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+SNAP_INSTANCE_NAME="$(readlink -f $0 | cut -f 3 -d /)"
+
+snap_connect_harder() {
+  # Note the available slot providers
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^content.*${SNAP_INSTANCE_NAME}:$1.*$"; then
+    available_providers="$(snap interface "$1" | sed -e '1,/slots:/d')"
+  else
+    available_providers="$(snap interface content | sed -e '1,/slots:/d' | grep "$1")"
+  fi
+
+  # For wayland try some well known providers
+  if [ "wayland" = "$1" ]; then
+    for PROVIDER in ubuntu-frame mir-kiosk; do
+       if echo "$available_providers" | grep --quiet "\- ${PROVIDER}"; then
+         sudo snap connect "${SNAP_INSTANCE_NAME}:$1" "${PROVIDER}:$1"
+         return 0
+       fi
+    done
+  fi
+
+  echo "Warning: Failed to connect '$1'. Please connect manually, available providers are:\n$available_providers"
+}
+
+for PLUG in %PLUGS%; do
+  if ! snap connections ${SNAP_INSTANCE_NAME} | grep --quiet "^.*${SNAP_INSTANCE_NAME}:${PLUG}.*${PLUG}.*$"; then
+    sudo snap connect "${SNAP_INSTANCE_NAME}:${PLUG}" 2> /dev/null || snap_connect_harder ${PLUG}
+  fi
+done

--- a/wayland-launch/bin/wayland-launch
+++ b/wayland-launch/bin/wayland-launch
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+for PLUG in %PLUGS%; do
+  if ! snapctl is-connected ${PLUG}
+  then
+    echo "WARNING: ${PLUG} interface not connected! Please run: /snap/${SNAP_INSTANCE_NAME}/current/bin/setup.sh"
+  fi
+done
+
+if ! command -v inotifywait > /dev/null
+then
+    echo "ERROR: inotifywait could not be found, mir-kiosk-snap-launch expects:"
+    echo " . . :     stage-packages:"
+    echo " . . :        - inotify-tools"
+    exit 1
+fi
+
+wait_for()
+{
+  until
+    until
+      inotifywait --event create "$(dirname "$1")"&
+      inotify_pid=$!
+      [ -e "$1" ] || sleep 2 && [ -e "$1" ]
+    do
+      wait "${inotify_pid}"
+    done
+    kill "${inotify_pid}"
+    [ -O "$1" ]
+  do
+    sleep 1
+  done
+}
+
+real_xdg_runtime_dir=$(dirname "${XDG_RUNTIME_DIR}")
+export WAYLAND_DISPLAY="${real_xdg_runtime_dir}/${WAYLAND_DISPLAY:-wayland-0}"
+
+# On core systems may need to wait for real XDG_RUNTIME_DIR
+wait_for "${real_xdg_runtime_dir}"
+wait_for "${WAYLAND_DISPLAY}"
+
+mkdir -p "$XDG_RUNTIME_DIR" -m 700
+unset DISPLAY
+
+exec "$@"


### PR DESCRIPTION
core24 needs to wait until Kodi 21 is available due to Python 3.12 incompatibility.